### PR TITLE
Usei regex pra adicionar o primeiro nome a Session para usar no menu

### DIFF
--- a/SemanaAcademica/Models/Usuario.cs
+++ b/SemanaAcademica/Models/Usuario.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Web;
 
 namespace SemanaAcademica
@@ -11,6 +12,7 @@ namespace SemanaAcademica
 
         public int IdPessoa { get; set; }
         public string Nome { get; set; }
+        public string NomeMenu { get; set; }
         public string Email { get; set; }
         public string Telefone { get; set; }
         public string Senha { get; set; }
@@ -39,6 +41,9 @@ namespace SemanaAcademica
 
                         if (pessoa != null)
                         {
+                            string regexPatternPrimeiroNome = "[\\w]+[^\\s+]";
+                            Regex r = new Regex(regexPatternPrimeiroNome, RegexOptions.IgnoreCase);
+                            Match m = r.Match(pessoa.Nome);
                             _SessionUser = new Usuario
                             {
                                 IdPessoa = pessoa.IdPessoa,
@@ -47,7 +52,8 @@ namespace SemanaAcademica
                                 Senha = pessoa.Senha,
                                 Telefone = pessoa.Telefone,
                                 IsColaborador = colaborador != null,
-                                IsAdministrador = administrador != null
+                                IsAdministrador = administrador != null,
+                                NomeMenu = m.Value
                             };
 
                             HttpContext.Current.Session[String.Format("UsuarioAutenticado.{0}", HttpContext.Current.User.Identity.Name)] = _SessionUser;

--- a/SemanaAcademica/Views/Shared/_LoginPartial.cshtml
+++ b/SemanaAcademica/Views/Shared/_LoginPartial.cshtml
@@ -2,7 +2,8 @@
 {
     <ul class="nav navbar-nav navbar-right">
         <li>
-            <a href="#">Olá, @SemanaAcademica.Usuario.SessionPersist.Nome!</a> @*Html.ActionLink(User.Identity.Name, "Manage", "Account", routeValues: null, htmlAttributes: new { @class = "username", title = "Manage" })!*@
+
+            <a href="#">Olá, @SemanaAcademica.Usuario.SessionPersist.NomeMenu!</a> @*Html.ActionLink(User.Identity.Name, "Manage", "Account", routeValues: null, htmlAttributes: new { @class = "username", title = "Manage" })!*@
         </li>
         <li>@Html.ActionLink("Sair", "Sair", new { area = "", controller = "Cadastro" })</li>
     </ul>


### PR DESCRIPTION
**Descrição:**
- O menu tava quebrando na opção responsiva, achamos que era só o tamanho do nome, então fiz uma implementação pra imprimir só o primeiro nome do usuário em vez do nome completo.
- Mesmo assim o menu continua quebrando, vai precisar dar mais uma olhada, talvez colocar tudo no hamburger menu quando tiver com menos de 992px de width.

**Teste:**
- Pra testar é necessário abrir o inspect do navegador e diminuir a width da tela.
- Assim é possível ver o menu quebrando e escondendo o titulo da área do site.

**Não adianta fazer o merge só disso que não vai resolver**
