### PR TITLE
Removi a lista dos horários na view de participação

### DIFF
--- a/SemanaAcademica/Areas/Admin/Views/Participacao/Registrar.cshtml
+++ b/SemanaAcademica/Areas/Admin/Views/Participacao/Registrar.cshtml
@@ -9,17 +9,7 @@
     <h1>
         @Html.DisplayFor(model => model.NomeEvento)
     </h1>
-    <p>
-        @for (int i = 0; i < Model.HoraFim.Count(); i++)
-        {
-            var hi = Model.HoraInicio[i];
-            var hf = Model.HoraFim[i];
-            <strong>
-                @hi.Date.ToShortDateString() @hi.Hour.ToString("00"):@hi.Minute.ToString("00") às @hf.Date.ToShortDateString() @hf.Hour.ToString("00"):@hf.Minute.ToString("00")
-                <br />
-            </strong>
-        }
-    </p><br><br>
+    <br><br>
     @using (Html.BeginForm())
     {
         <div class="form-group">


### PR DESCRIPTION
**Descrição:**
Quando o usuário selecionar um evento do DropDownList no menu participação, deverá aparecer apenas o nome do evento agora e não mais todos os horários daquele evento. Evitando confundir os usuários que irão operar as entradas e saídas do evento.

**Teste:**
- Pra testar é necessário entrar em participação.
- Escolher um evento disponível no dropdown e clicar no botão de selecionar.
- A próxima tela deverá ter como título apenas o nome do evento, não mais mostrando todos os horários cadastrados daquele evento.
